### PR TITLE
Add aria-labels to remove buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
         party: (cls) => <Icon label="party" className={cls}>🎉</Icon>,
         users: (cls) => <Icon label="users" className={cls}>👥</Icon>,
         plus: (cls) => <Icon label="add" className={cls}>＋</Icon>,
-        trash: (cls) => <Icon label="remove" className={cls}>🗑️</Icon>,
+        trash: (cls) => <Icon label="Remove" className={cls}>🗑️</Icon>,
         shuffle: (cls) => <Icon label="shuffle" className={cls}>🔀</Icon>,
         volOn: (cls) => <Icon label="volume on" className={cls}>🔊</Icon>,
         volOff: (cls) => <Icon label="volume off" className={cls}>🔇</Icon>,
@@ -297,7 +297,7 @@
                   <li key={p.id} className="flex items-center gap-3 py-2">
                     <input type="checkbox" checked={p.present} onChange={() => onToggle(p.id)} className="accent-emerald-600 w-4 h-4" />
                     <span className={`flex-1 ${p.present ? "" : "opacity-50"}`}>{p.name}</span>
-                    <button onClick={() => onRemove(p.id)} className="p-1.5 rounded-full hover:bg-rose-100/60" title="Remove">{Icons.trash("text-base")}</button>
+                    <button onClick={() => onRemove(p.id)} className="p-1.5 rounded-full hover:bg-rose-100/60" title="Remove" aria-label="Remove">{Icons.trash("text-base")}</button>
                   </li>
                 ))}
               </ul>
@@ -376,7 +376,7 @@ function QuestionsEditor({ questions, setQuestions }){
                   <li key={i} className="flex items-start gap-3 py-2">
                     <span className="text-slate-500 text-xs mt-1">{i + 1}.</span>
                     <span className="flex-1 text-sm">{q}</span>
-                    <button onClick={() => removeQuestion(i)} className="p-1.5 rounded-full hover:bg-rose-100/60" title="Remove">{Icons.trash("text-base")}</button>
+                    <button onClick={() => removeQuestion(i)} className="p-1.5 rounded-full hover:bg-rose-100/60" title="Remove" aria-label="Remove">{Icons.trash("text-base")}</button>
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary
- add `aria-label` matching the tooltip for icon-only remove buttons in team and question lists
- align trash icon label text with button title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d9ef9f21c832cbcbfcbc46939d9d2