### PR TITLE
Fix class attribute in error overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
     <div id="error-overlay"><div class="box">
       <div class="mb-2 font-semibold">An error occurred:</div>
       <pre id="error-text"></pre>
-      <div className="text-xs opacity-80 mt-2">Open the browser console for details.</div>
+      <div class="text-xs opacity-80 mt-2">Open the browser console for details.</div>
     </div></div>
     <script>
       (function(){


### PR DESCRIPTION
## Summary
- Correct `className` to `class` in static error overlay markup so styles apply

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689d9c10eb3c832c95cf0b98c647d2fa