### PR TITLE
docs: fix persistence heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Later, click **Import** and select that JSON to restore your setup.
 
 > **Best practice:** export after any large edits, and keep the file in version control or cloud storage.
 
-## 🧠 Persistency (Browser Cache)
+## 🧠 Persistence (Browser Cache)
 - The app stores your data in **LocalStorage** under keys:
   - `woq_team_v4` (team list)
   - `woq_questions_v1` (questions)


### PR DESCRIPTION
## Summary
- replace 'Persistency' with 'Persistence' in README

## Testing
- `npm test` (fails: ENOENT, could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689da007aa54832c855a3c372808e0e8