### PR TITLE
Fix error overlay attribute for proper styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
     <div id="error-overlay"><div class="box">
       <div class="mb-2 font-semibold">An error occurred:</div>
       <pre id="error-text"></pre>
-      <div className="text-xs opacity-80 mt-2">Open the browser console for details.</div>
+      <div class="text-xs opacity-80 mt-2">Open the browser console for details.</div>
     </div></div>
     <script>
       (function(){


### PR DESCRIPTION
## Summary
- Use standard `class` attribute in the error overlay message element so Tailwind styles apply correctly.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da008f0c8832c986bb28248842752