### PR TITLE
feat: defer Babel script execution

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
     </script>
 
     <!-- App (compiled by Babel in the browser) -->
-    <script type="text/babel" data-presets="env,react">
+    <script type="text/babel" data-presets="env,react" defer>
       const { useEffect, useMemo, useState } = React;
       const FM = window.framerMotion || window.FramerMotion || window.framermotion || null;
       const motion = FM ? FM.motion : new Proxy({}, { get: () => (props) => React.createElement('div', props, props && props.children) });


### PR DESCRIPTION
## Summary
- defer in-browser Babel script to run after React and ReactDOM load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689da84431c8832c88c1a70439ffbe75