### PR TITLE
fix: pin React CDN versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,11 +24,11 @@
     } } };</script>
 
     <!-- React + ReactDOM (UMD) -->
-    <script src="https://unpkg.com/react@18/umd/react.production.min.js"
+    <script src="https://unpkg.com/react@18.2.0/umd/react.production.min.js"
             integrity="sha256-S0lp+k7zWUMk2ixteM6HZvu8L9Eh//OVrt+ZfbCpmgY="
             crossorigin="anonymous"
             onerror="this.removeAttribute('integrity'); this.src='vendor/react.production.min.js';"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
+    <script src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js"
             integrity="sha256-IXWO0ITNDjfnNXIu5POVfqlgYoop36bDzhodR6LW5Pc="
             crossorigin="anonymous"
             onerror="this.removeAttribute('integrity'); this.src='vendor/react-dom.production.min.js';"></script>


### PR DESCRIPTION
## Summary
- pin React and ReactDOM CDN scripts to version 18.2.0 to keep integrity hashes stable

## Testing
- `npm test`
- `node -e "const fs=require('fs'),vm=require('vm');const context={};context.self=context;context.window=context;vm.runInContext(fs.readFileSync('vendor/react.production.min.js','utf8'),vm.createContext(context));console.log(typeof context.React);"`


------
https://chatgpt.com/codex/tasks/task_e_689da83cc880832c80fd7439c897edad