### PR TITLE
Load Tailwind CDN after defining global config

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,6 @@
     <title>Nextview Wheel of Questions — Party Mode (No‑CDN Confetti)</title>
 
     <!-- Tailwind CSS (CDN) -->
-    <script src="https://cdn.tailwindcss.com"
-            integrity="sha256-eTPiE7OfNDSwTrJNIZ8nlZapx9n3gz9+Oo2zzr5+adM="
-            crossorigin="anonymous"
-            onerror="this.removeAttribute('integrity'); this.src='vendor/tailwindcss.js';"></script>
     <script>tailwind.config = { theme: { extend: {
       keyframes: {
         huepulse: { '0%, 100%': { filter: 'hue-rotate(0deg)' }, '50%': { filter: 'hue-rotate(45deg)' } },
@@ -22,6 +18,10 @@
         shimmer: 'shimmer 12s linear infinite'
       }
     } } };</script>
+    <script src="https://cdn.tailwindcss.com"
+            integrity="sha256-eTPiE7OfNDSwTrJNIZ8nlZapx9n3gz9+Oo2zzr5+adM="
+            crossorigin="anonymous"
+            onerror="this.removeAttribute('integrity'); this.src='vendor/tailwindcss.js';"></script>
 
     <!-- React + ReactDOM (UMD) -->
     <script src="https://unpkg.com/react@18.2.0/umd/react.production.min.js"


### PR DESCRIPTION
## Summary
- ensure `tailwind.config` global is defined before loading the Tailwind CDN script so custom keyframes and animations are applied

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689daa5dc3b0832ca6baa496a4cb03cc