### PR TITLE
Pin external scripts to specific versions and remove CORS attrs

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,25 +31,17 @@
 
     <!-- React + ReactDOM (UMD) -->
     <script src="https://unpkg.com/react@18.2.0/umd/react.production.min.js"
-            integrity="sha256-S0lp+k7zWUMk2ixteM6HZvu8L9Eh//OVrt+ZfbCpmgY="
-            crossorigin="anonymous"
-            onerror="this.removeAttribute('integrity'); this.src='vendor/react.production.min.js';"></script>
+            onerror="this.src='vendor/react.production.min.js';"></script>
     <script src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js"
-            integrity="sha256-IXWO0ITNDjfnNXIu5POVfqlgYoop36bDzhodR6LW5Pc="
-            crossorigin="anonymous"
-            onerror="this.removeAttribute('integrity'); this.src='vendor/react-dom.production.min.js';"></script>
+            onerror="this.src='vendor/react-dom.production.min.js';"></script>
 
     <!-- Babel Standalone (compile JSX in-browser) -->
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"
-            integrity="sha256-3jyRlQ0KMnYi6xl+R2rZQ5JO1xam48suhyxFJgS/Ups="
-            crossorigin="anonymous"
-            onerror="this.removeAttribute('integrity'); this.src='vendor/babel.min.js';"></script>
+    <script src="https://unpkg.com/@babel/standalone@7.28.2/babel.min.js"
+            onerror="this.src='vendor/babel.min.js';"></script>
 
     <!-- framer-motion (UMD) -->
-    <script src="https://unpkg.com/framer-motion/dist/framer-motion.umd.js"
-            integrity="sha256-OCEzkN+dIx4tkYIBp41/w69A+VAJqPD1wGImv1vXAw4="
-            crossorigin="anonymous"
-            onerror="this.removeAttribute('integrity'); this.src='vendor/framer-motion.js';"></script>
+    <script src="https://unpkg.com/framer-motion@11/dist/framer-motion.umd.js"
+            onerror="this.src='vendor/framer-motion.js';"></script>
 
     <style>
       html, body, #root { height: 100%; }


### PR DESCRIPTION
## Summary
- Pin React, ReactDOM, Babel and Framer Motion scripts to fixed unpkg versions
- Drop `crossorigin`/`integrity` attributes and keep local fallbacks to avoid CORS errors

## Testing
- `npm test`
- `node -e "const puppeteer=require('puppeteer');(async()=>{const b=await puppeteer.launch({headless:'new',args:['--no-sandbox','--disable-setuid-sandbox']});const p=await b.newPage();p.on('console',m=>console.log('CONSOLE',m.type(),m.text()));p.on('pageerror',e=>console.log('PAGEERROR',e.message));p.on('requestfailed',r=>console.log('REQUESTFAILED',r.url(),r.failure().errorText));await p.goto('file://'+process.cwd()+'/index.html');await new Promise(r=>setTimeout(r,1000));await b.close();})();"`

------
https://chatgpt.com/codex/tasks/task_e_689dace65c90832cac31c0960fb07e3f