### PR TITLE
feat: add crypto-based shuffle bag

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,9 +77,11 @@
       })();
     </script>
 
+    <script src="src/shuffleBag.js"></script>
+
     <!-- App (compiled by Babel in the browser) -->
     <script type="text/babel" data-presets="env,react" defer>
-      const { useEffect, useMemo, useState } = React;
+      const { useEffect, useMemo, useRef, useState } = React;
       const FM = window.framerMotion || window.FramerMotion || window.framermotion || null;
       const motion = FM ? FM.motion : new Proxy({}, { get: () => (props) => React.createElement('div', props, props && props.children) });
       const AnimatePresence = FM ? FM.AnimatePresence : ({ children }) => React.createElement(React.Fragment, null, children);
@@ -441,7 +443,13 @@ function QuestionsEditor({ questions, setQuestions }){
           return () => window.removeEventListener("pointerdown", handler);
         }, []);
 
+        const personBag = useRef(new ShuffleBag());
+        const questionBag = useRef(new ShuffleBag());
+
         const presentTeam = useMemo(() => team.filter(t => t.present), [team]);
+
+        useEffect(() => { personBag.current.reset(presentTeam); }, [presentTeam]);
+        useEffect(() => { questionBag.current.reset(questions); }, [questions]);
 
         function pickRandomPersonSlot(){
           if (!presentTeam.length || slotPersonRunning) return;
@@ -458,7 +466,7 @@ function QuestionsEditor({ questions, setQuestions }){
           const stopAfter = Math.floor(Math.random()*800) + 1800;
           setTimeout(() => {
             clearInterval(interval);
-            const final = presentTeam[Math.floor(Math.random()*presentTeam.length)];
+            const final = personBag.current.next();
             setSlotName(final.name);
             setSelectedPerson(final);
             setSlotPersonRunning(false);
@@ -483,8 +491,7 @@ function QuestionsEditor({ questions, setQuestions }){
           const stopAfter = Math.floor(Math.random()*800) + 1800;
           setTimeout(() => {
             clearInterval(interval);
-            const index = Math.floor(Math.random()*questions.length);
-            const final = questions[index];
+            const final = questionBag.current.next();
             setSlotText(final);
             setSelectedQuestion(final);
             setSlotQuestionRunning(false);

--- a/src/shuffleBag.js
+++ b/src/shuffleBag.js
@@ -1,0 +1,51 @@
+(function (global, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    global.ShuffleBag = factory();
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  const cryptoObj = (typeof globalThis !== 'undefined' && globalThis.crypto) ? globalThis.crypto : (typeof require === 'function' ? require('crypto').webcrypto : null);
+  if (!cryptoObj || typeof cryptoObj.getRandomValues !== 'function') {
+    throw new Error('crypto.getRandomValues is required');
+  }
+
+  function randomInt(max) {
+    const buf = new Uint32Array(1);
+    cryptoObj.getRandomValues(buf);
+    return buf[0] % max;
+  }
+
+  class ShuffleBag {
+    constructor(items = []) {
+      this.items = [];
+      this.index = 0;
+      this.reset(items);
+    }
+
+    reset(items = []) {
+      this.items = Array.from(items);
+      this.shuffle();
+    }
+
+    shuffle() {
+      const arr = this.items;
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = randomInt(i + 1);
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      this.index = 0;
+    }
+
+    next() {
+      if (this.items.length === 0) return undefined;
+      if (this.index >= this.items.length) {
+        this.shuffle();
+      }
+      return this.items[this.index++];
+    }
+  }
+
+  return ShuffleBag;
+});
+

--- a/tests/ShuffleBag.test.js
+++ b/tests/ShuffleBag.test.js
@@ -1,0 +1,23 @@
+const ShuffleBag = require('../src/shuffleBag');
+
+describe('ShuffleBag', () => {
+  test('provides each item once before repeating', () => {
+    const bag = new ShuffleBag(['a', 'b', 'c']);
+    const firstCycle = [bag.next(), bag.next(), bag.next()];
+    expect(new Set(firstCycle).size).toBe(3);
+    const secondCycle = [bag.next(), bag.next(), bag.next()];
+    expect(new Set(secondCycle).size).toBe(3);
+  });
+
+  test('reset reshuffles items', () => {
+    const bag = new ShuffleBag([1, 2, 3]);
+    const a = bag.next();
+    bag.reset(['x', 'y']);
+    expect(['x', 'y']).toContain(bag.next());
+  });
+
+  test('returns undefined when empty', () => {
+    const bag = new ShuffleBag([]);
+    expect(bag.next()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Implement reusable crypto-backed ShuffleBag for unbiased item cycling
- Use ShuffleBag for person and question slot machines to avoid immediate repeats
- Add unit tests for ShuffleBag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dafb19c68832c9252404fb125ef9e