### PR TITLE
Use local framer-motion bundle

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,9 +31,8 @@
     <script src="https://unpkg.com/@babel/standalone@7.28.2/babel.min.js"
             onerror="this.src='vendor/babel.min.js';"></script>
 
-    <!-- framer-motion (UMD) -->
-    <script src="https://unpkg.com/framer-motion@11/dist/framer-motion.umd.js"
-            onerror="this.src='vendor/framer-motion.js';"></script>
+    <!-- framer-motion (local bundle) -->
+    <script src="vendor/framer-motion.js"></script>
 
     <style>
       html, body, #root { height: 100%; }


### PR DESCRIPTION
## Summary
- load framer-motion from bundled `vendor/framer-motion.js` instead of CDN

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in src/shuffleBag.js)*

------
https://chatgpt.com/codex/tasks/task_e_689db59a93c8832ca6f853ce869c2354