### PR TITLE
Fix runtime errors in browser console

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,12 @@
 
     <!-- Tailwind CSS -->
 
-    <script>window.tailwind = { config: { theme: { extend: {
+    <script>
+      // Expose a Tailwind config before the library loads.
+      // Some browsers expect a global `tailwind` variable, so make sure
+      // both `window.tailwind` and `tailwind` point to the config object.
+      window.tailwind = {
+        config: { theme: { extend: {
       keyframes: {
         huepulse: { '0%, 100%': { filter: 'hue-rotate(0deg)' }, '50%': { filter: 'hue-rotate(45deg)' } },
         floaty: { '0%': { transform: 'translateY(0px)' }, '50%': { transform: 'translateY(-10px)' }, '100%': { transform: 'translateY(0px)' } },
@@ -18,7 +23,10 @@
         floaty: 'floaty 4s ease-in-out infinite',
         shimmer: 'shimmer 12s linear infinite'
       }
-    } } } };</script>
+    } } } };
+      // Define the global variable so `tailwind` lookups succeed.
+      var tailwind = window.tailwind;
+    </script>
     <script src="vendor/tailwindcss.js"></script>
 
     <!-- React + ReactDOM (UMD) -->
@@ -82,7 +90,8 @@
     <!-- App (compiled by Babel in the browser) -->
     <script type="text/babel" data-presets="env,react" defer>
       const { useEffect, useMemo, useRef, useState } = React;
-      const FM = window.framerMotion || window.FramerMotion || window.framermotion || null;
+      // framer-motion exposes different globals depending on the build.
+      const FM = window.framerMotion || window.FramerMotion || window.framermotion || window.Motion || null;
       const motion = FM ? FM.motion : new Proxy({}, { get: () => (props) => React.createElement('div', props, props && props.children) });
       const AnimatePresence = FM ? FM.AnimatePresence : ({ children }) => React.createElement(React.Fragment, null, children);
 

--- a/src/shuffleBag.js
+++ b/src/shuffleBag.js
@@ -1,10 +1,15 @@
-let secureRandomInt;
+// Attempt to use a cryptographically secure RNG if available, but
+// gracefully fall back to Math.random so the app can still function
+// in environments where `secureRandomInt` hasn't been defined yet.
+let secureRandomInt = (max) => Math.floor(Math.random() * max);
 if (typeof window !== 'undefined' && typeof window.secureRandomInt === 'function') {
   secureRandomInt = window.secureRandomInt;
 } else if (typeof require === 'function') {
-  secureRandomInt = require('./random').secureRandomInt;
-} else {
-  throw new Error('secureRandomInt is not available');
+  try {
+    secureRandomInt = require('./random').secureRandomInt;
+  } catch (e) {
+    // ignore and use the Math.random fallback
+  }
 }
 
 class ShuffleBag {


### PR DESCRIPTION
## Summary
- Define global Tailwind config so browsers don't throw `tailwind` reference errors
- Gracefully fall back to non-crypto RNG in `ShuffleBag` to avoid initialization failures
- Detect alternate framer-motion global

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689db71a54a8832c9714ca2b4e86bf50