### PR TITLE
Resolve package-lock merge conflicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
         "jest": "^30.0.5",
         "jest-canvas-mock": "^2.5.2",
         "jest-environment-jsdom": "^30.0.5",
@@ -62,6 +63,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@babel/cli/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1175,6 +1186,14 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1885,7 +1904,8 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "optional": true
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -2061,7 +2081,8 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
+      },
+      "optional": true
     },
     "node_modules/chokidar/node_modules/glob-parent": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "jest": "^30.0.5",
     "jest-canvas-mock": "^2.5.2",
     "jest-environment-jsdom": "^30.0.5",
-    "tailwindcss": "^3.4.4"
+    "tailwindcss": "^3.4.4",
+    "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3"
   },
   "jest": {
     "testEnvironment": "jsdom"


### PR DESCRIPTION
## Summary
- merge resolved package-lock.json conflicts, restoring watcher dependencies
- mark `binary-extensions` and `chokidar` as optional and keep glob-parent subtree
- ensure `pify` versions (2.3.0 root, 4.0.1 for `@babel/cli`) and add `@nicolo-ribaudo/chokidar-2`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc3594820832cb01367110993c18b