### PR TITLE
Fix framer-motion import and entry script path

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
     <!-- Tailwind CSS -->
     <link href="tailwind.css" rel="stylesheet" />
 
-    <!-- framer-motion (local bundle) -->
-    <script src="vendor/framer-motion.js"></script>
 
     <style>
       html, body, #root { height: 100%; }
@@ -54,6 +52,6 @@
     </script>
 
 
-    <script type="module" src="/dist/main.js"></script>
+    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "framer-motion": "^11.2.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -3428,6 +3429,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4826,6 +4854,21 @@
         "color-name": "^1.1.4"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6206,9 +6249,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "license": "ISC",
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "framer-motion": "^11.2.8"
   },
   "devDependencies": {
     "jest": "^30.0.5",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { secureRandomInt } from "./random.js";
 import ShuffleBag from "./shuffleBag.js";
 import ConfettiEngine from "../ConfettiEngine.js";
-
-// framer-motion exposes different globals depending on the build.
-const FM = window.framerMotion || window.FramerMotion || window.framermotion || window.Motion || null;
-const motion = FM ? FM.motion : new Proxy({}, { get: () => (props) => React.createElement('div', props, props && props.children) });
-const AnimatePresence = FM ? FM.AnimatePresence : ({ children }) => React.createElement(React.Fragment, null, children);
 
 // Confetti engine shared module
 const PARTY = new ConfettiEngine(document.getElementById('party-canvas'));
@@ -115,14 +111,14 @@ function SlotCard({ bigText, smallText, emoji, highlight=false, spotlight=false,
           </div>
           <div className="flex-1 grid place-items-center text-center px-2">
             <div className="w-full">
-              {React.createElement(motion.div || 'div', {
+              {React.createElement(motion.div, {
                 key: bigText,
                 initial: { y: 8, opacity: 0, rotate: -0.5 },
                 animate: { y: 0, opacity: 1, rotate: 0 },
                 transition: { type: 'spring', stiffness: 500, damping: 30 },
                 className: "text-3xl sm:text-5xl md:text-6xl font-extrabold tracking-tight leading-tight md:leading-snug whitespace-pre-wrap break-words"
               }, bigText)}
-              {smallText && React.createElement(motion.div || 'div', {
+              {smallText && React.createElement(motion.div, {
                 key: smallText,
                 initial: { opacity: 0 },
                 animate: { opacity: 1 },
@@ -136,7 +132,7 @@ function SlotCard({ bigText, smallText, emoji, highlight=false, spotlight=false,
 
       {React.createElement(AnimatePresence, null,
         spotlight ? React.createElement('div', { className:"absolute inset-0 rounded-3xl bg-black/40 backdrop-blur-sm flex items-center justify-center z-10" },
-          React.createElement(motion.div || 'div', {
+          React.createElement(motion.div, {
             initial:{ scale: 0.9, rotate: -2 },
             animate:{ scale: 1, rotate: 0 },
             exit:{ scale: 0.95, opacity: 0 },


### PR DESCRIPTION
## Summary
- Import framer-motion via npm package and use its `motion` and `AnimatePresence` components directly
- Remove vendor framer-motion script and point index.html to Vite entry `src/main.jsx`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dd1a33fcc832ca7c64dd85cfe8d24