### PR TITLE
fix: use relative path for entry module

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
     </script>
 
 
-    <script type="module" src="/src/main.jsx"></script>
+    <!-- Use a relative path so GitHub Pages serves the module from the repo subdirectory -->
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- make the app load correctly on GitHub Pages by using a relative script path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dd6c9b884832cbc98c4011d258baa